### PR TITLE
Implemented PHP version of `DateTimeWithUtcCompanion` and `ZonedDateTimePersistence`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+tests export-ignore
+Dockerfile export-ignore
+bin export-ignore
+.github export-ignore
+.molireali export-ignore

--- a/.github/FUNDING.yaml
+++ b/.github/FUNDING.yaml
@@ -1,0 +1,1 @@
+custom: https://petrknap.github.io/donate.html

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+- [ ] This pull request does not contain any breaking change.
+- [ ] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
+<!-- ⇅ remove it if it doesn't make sense ⇅ -->
+<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
+>> Could you briefly summarize the following code for me?
+>> ```python
+>> class Tiger:
+>>    def __init__(self, name):
+>>       self.name = name
+>>
+>>    def roar(self):
+>>       print(f"{self.name} lets out a powerful roar!")
+>> ```
+>
+> This code defines a Python class named `Tiger` with a constructor that initializes the tiger's name, and a `roar` method that prints a message including the tiger's name. Simple and elegant, just like a tiger! 🐅
+>
+>> Could you show me how to use it?
+>
+> Sure, here's how to create and use a `Tiger` object with the class you have:
+> ```python
+> # Create an instance of Tiger
+> my_tiger = Tiger("Gopal")
+> 
+> # Call the roar method
+> my_tiger.roar()
+> ```
+>
+> When you run this code, it will output:
+> ```
+> Gopal lets out a powerful roar!
+> ```
+>
+> That's how you bring your Tiger to life! 🎉
+>
+>> Is there any way to do it better?
+>
+> Absolutely. You could add error handling, additional methods, or even inheritance. Here's an enhanced version:
+> ```python
+> class Tiger:
+>     def __init__(self, name):
+>         self.name = name
+> 
+>     def roar(self):
+>         print(f"{self.name} lets out a powerful roar!")
+> 
+>     def introduce(self):
+>         print(f"Meet {self.name}, the majestic tiger!")
+>
+> # Usage
+> my_tiger = Tiger("Gopal")
+> my_tiger.introduce()  # Output: Meet Gopal, the majestic tiger!
+> my_tiger.roar()  # Output: Gopal lets out a powerful roar!
+> ```
+>
+> Now your tiger can introduce itself, too. 🐯📢
+<!-- ↑ this is an example, replace it ↑ -->

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,13 @@
+name: composer ci-script
+
+on:
+  pull_request:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: docker build -t $GITHUB_REPOSITORY:$GITHUB_SHA .
+      - name: Run composer ci-script
+        run: docker run $GITHUB_REPOSITORY:$GITHUB_SHA composer ci-script

--- a/.github/workflows/linter-docker.yaml
+++ b/.github/workflows/linter-docker.yaml
@@ -1,0 +1,17 @@
+name: Docker Linter
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '**/Dockerfile'
+      - '**.dockerfile'
+
+jobs:
+  HaskellDockerfileLinter:
+    runs-on: ubuntu-latest
+    container:
+      image: hadolint/hadolint:latest-alpine
+    steps:
+      - uses: actions/checkout@v3
+      - run: find . -name 'Dockerfile' -or -name '*.dockerfile' | xargs -trn 1 hadolint

--- a/.github/workflows/linter-php.yaml
+++ b/.github/workflows/linter-php.yaml
@@ -1,0 +1,15 @@
+name: PHP Linter
+
+on:
+  pull_request:
+    paths:
+      - '**.php'
+
+jobs:
+  PHP:
+    runs-on: ubuntu-latest
+    container:
+      image: php:8.1-cli-alpine
+    steps:
+      - uses: actions/checkout@v3
+      - run: find . -name '*.php' | xargs -trn 1 php -l

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/vendor/
+/composer.lock

--- a/.molireali
+++ b/.molireali
@@ -1,0 +1,10 @@
+authors
+composer PetrKnap\\ZonedDateTimePersistence
+dockerfile php 8.1-cli
+docker-scripts petrknap/zoned-datetime-persistence
+donation
+github-templates
+github-workflow docker "composer ci-script"
+github-workflow linter-docker
+github-workflow linter-php 8.1
+license LGPL-3.0-or-later

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,3 @@
+# This is the official list of authors for copyright purposes.
+
+Petr Knap <8299754+petrknap@users.noreply.github.com>

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/COPYING.LESSER
+++ b/COPYING.LESSER
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM php:8.1-cli
+
+# region included composer
+# hadolint ignore=DL3008
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      git \
+      unzip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+;
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+# endregion
+
+# region included composer-library
+WORKDIR /app
+COPY . .
+RUN composer update --prefer-lowest
+# endregion

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# zoned-datetime-persistence
+# Timezone aware date-time persistence
+
+Most SQL databases (like MySQL) do not natively support storing time zone information alongside `DATETIME` / `TIMESTAMP` values.
+This leads to ambiguity when saving date-time, especially in applications running in multiple timezones.
+
+This package solves that by providing tools to work with date-time as a couple of:
+- the date-time value in timezone of source data, and
+- the companion value which holds the timezone information on the other side.
+
+
+
+## Date-time with UTC companion
+
+The **most useful** thing is to save date-time with its UTC companion.
+This makes it possible to **work with date and time directly in SQL**.
+The original date is perfect for grouping and filtering, while UTC time is needed for correct sorting.
+
+```php
+use PetrKnap\ZonedDateTimePersistence\DateTimeWithUtcCompanion;
+use PetrKnap\ZonedDateTimePersistence\ZonedDateTimePersistence;
+
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE notes (created_at DATETIME, created_at__utc DATETIME, content TEXT)');
+$dbDateTimeFormat = 'Y-m-d H:i:s';
+
+$insert = $db->prepare('INSERT INTO notes VALUES (?, ?, ?)');
+# static call usage
+$now = new DateTime('2025-10-26 02:45', new DateTimeZone('CEST'));
+$insert->execute([
+    $now->format($dbDateTimeFormat),
+    ZonedDateTimePersistence::computeUtcCompanion($now)->format($dbDateTimeFormat),
+    'We still have summer time',
+]);
+# record usage
+$now = new DateTimeWithUtcCompanion(new DateTime('2025-10-26 02:15', new DateTimeZone('CET')));
+$insert->execute([
+    $now->dateTime->format($dbDateTimeFormat),
+    $now->utcCompanion->format($dbDateTimeFormat),
+    'Now we have winter time',
+]);
+
+$select = $db->query('SELECT * FROM notes WHERE strftime("%Y", created_at) = "2025" ORDER BY created_at__utc ASC');
+foreach($select->fetchAll(PDO::FETCH_ASSOC) as $note) {
+    printf(
+        '%s: %s' . PHP_EOL,
+        ZonedDateTimePersistence::computeZonedDateTime(
+            $note['created_at'],
+            $note['created_at__utc'],
+            $dbDateTimeFormat,
+        )->format('Y-m-d H:i T'),
+        $note['content'],
+    );
+}
+```
+
+---
+
+Run `composer require petrknap/zoned-datetime-persistence` to install it.
+You can [support this project via donation](https://petrknap.github.io/donate.html).
+The project is licensed under [the terms of the `LGPL-3.0-or-later`](./COPYING.LESSER).

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,58 @@
+{
+  "autoload": {
+    "psr-4": {
+      "PetrKnap\\ZonedDateTimePersistence\\": "src/main/php"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "PetrKnap\\ZonedDateTimePersistence\\": "src/test/php"
+    }
+  },
+  "config": {
+    "allow-plugins": false,
+    "sort-packages": true
+  },
+  "description": "Timezone aware date-time persistence",
+  "funding": [
+    {
+      "type": "other",
+      "url": "https://petrknap.github.io/donate.html"
+    }
+  ],
+  "homepage": "https://github.com/petrknap/zoned-datetime-persistence",
+  "keywords": [],
+  "license": "LGPL-3.0-or-later",
+  "name": "petrknap/zoned-datetime-persistence",
+  "require": {
+    "php": ">=8.1"
+  },
+  "require-dev": {
+    "nunomaduro/phpinsights": "^2.11",
+    "petrknap/shorts": "^3.0",
+    "phpstan/phpstan": "^1.12",
+    "phpunit/phpunit": "^10.5",
+    "squizlabs/php_codesniffer": "^3.7"
+  },
+  "scripts": {
+    "test": "phpunit --colors=always --testdox src/test",
+    "check-implementation": [
+      "phpcs --colors --standard=PSR12 --exclude=Generic.Files.LineLength src/main/php src/test",
+      "phpstan analyse --level max src/main/php --ansi --no-interaction",
+      "phpstan analyse --level 5 src/test --ansi --no-interaction",
+      "phpinsights analyse src/main/php src/test --ansi --no-interaction --format=github-action | sed -e \"s#::error file=$PWD/#::notice file=#g\""
+    ],
+    "check-requirements": [
+      "composer update \"petrknap/*\"",
+      "composer outdated \"petrknap/*\" --major-only --strict --ansi --no-interaction"
+    ],
+    "test-implementation": [
+      "@test"
+    ],
+    "ci-script": [
+      "@check-implementation",
+      "@check-requirements",
+      "@test-implementation"
+    ]
+  }
+}

--- a/src/main/php/DateTimeUtils.php
+++ b/src/main/php/DateTimeUtils.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\ZonedDateTimePersistence;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+use RuntimeException;
+
+/**
+ * @internal helper
+ *
+ * @phpstan-import-type LocalDateTime from JavaSe8\Time
+ * @phpstan-import-type ZonedDateTime from JavaSe8\Time
+ */
+final class DateTimeUtils
+{
+    /**
+     * @param LocalDateTime $localDateTime
+     * @param int $offset seconds
+     *
+     * @return ZonedDateTime
+     */
+    public static function atOffset(
+        DateTimeImmutable $localDateTime,
+        int $offset,
+    ): DateTimeImmutable {
+        /** @var ZonedDateTime */
+        return $localDateTime->setTimezone(self::offsetTimezone($offset));
+    }
+
+    /**
+     * @param ($format is null ? DateTimeInterface : string) $zonedDateTime
+     *
+     * @return ZonedDateTime
+     */
+    public static function parse(
+        DateTimeInterface|string $zonedDateTime,
+        string|null $format = null,
+    ): DateTimeImmutable {
+        $zonedDateTime = $format === null
+            ? $zonedDateTime
+            : DateTimeImmutable::createFromFormat($format, $zonedDateTime)
+        ;
+        if ($zonedDateTime === false) {
+            throw new RuntimeException('Could not parse $zonedDateTime as $format');
+        }
+        return JavaSe8\Time::zonedDateTime($zonedDateTime);
+    }
+
+    /**
+     * @return int seconds
+     */
+    public static function difference(
+        DateTimeInterface $a,
+        DateTimeInterface $b,
+    ): int {
+        return $a->getTimestamp() - $b->getTimestamp();
+    }
+
+    public static function offsetTimezone(int $offset): DateTimeZone
+    {
+        return new DateTimeZone(sprintf(
+            '%s%02d:%02d',
+            $offset >= 0 ? '+' : '-',
+            abs(intdiv($offset, 3600)),
+            abs(($offset % 3600) / 60),
+        ));
+    }
+}

--- a/src/main/php/DateTimeWithUtcCompanion.php
+++ b/src/main/php/DateTimeWithUtcCompanion.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\ZonedDateTimePersistence;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use LogicException;
+
+/**
+ * @phpstan-import-type LocalDateTime from JavaSe8\Time
+ * @phpstan-import-type ZonedDateTime from JavaSe8\Time
+ *
+ * @phpstan-type ConstructorArgs array{0: ZonedDateTime, 1: ZonedDateTime}
+ */
+final class DateTimeWithUtcCompanion
+{
+    /**
+     * @var ZonedDateTime
+     */
+    public readonly DateTimeImmutable $dateTime;
+    /**
+     * @var ZonedDateTime
+     */
+    public readonly DateTimeImmutable $utcCompanion;
+
+    public function __construct(
+        DateTimeInterface $dateTime,
+        DateTimeInterface|null $utcCompanion = null,
+    ) {
+        if ($utcCompanion === null) {
+            [$dateTime, $utcCompanion] = self::createArgsFromZonedDateTime($dateTime);
+        } elseif ($dateTime->getOffset() === $utcCompanion->getOffset()) {
+            [$dateTime, $utcCompanion] = self::createArgsFromLocalDateTimes($dateTime, $utcCompanion);
+        } else {
+            [$dateTime, $utcCompanion] = self::createArgsFromZonedDateTimes($dateTime, $utcCompanion);
+        }
+
+        $this->dateTime = $dateTime;
+        $this->utcCompanion = $utcCompanion;
+
+        if ($this->utcCompanion->getOffset() !== 0) {
+            throw new LogicException('$utcCompanion must have zero offset');
+        } elseif (DateTimeUtils::difference($this->dateTime, $this->utcCompanion) !== 0) {
+            throw new LogicException('$dateTime and $utcCompanion must have zero difference');
+        }
+    }
+
+    /**
+     * @return ConstructorArgs
+     */
+    private function createArgsFromLocalDateTimes(DateTimeInterface $dateTime, DateTimeInterface $utcCompanion): array
+    {
+        return self::createArgsFromZonedDateTime(
+            ZonedDateTimePersistence::computeZonedDateTime($dateTime, $utcCompanion),
+        );
+    }
+
+    /**
+     * @return ConstructorArgs
+     */
+    private function createArgsFromZonedDateTime(DateTimeInterface $dateTime): array
+    {
+        $zonedDateTime = JavaSe8\Time::zonedDateTime($dateTime);
+
+        return [
+            $zonedDateTime,
+            ZonedDateTimePersistence::computeUtcCompanion($zonedDateTime),
+        ];
+    }
+
+    /**
+     * @return ConstructorArgs
+     */
+    private function createArgsFromZonedDateTimes(DateTimeInterface $dateTime, DateTimeInterface $utcCompanion): array
+    {
+        return [
+            JavaSe8\Time::zonedDateTime($dateTime),
+            JavaSe8\Time::zonedDateTime($utcCompanion),
+        ];
+    }
+}

--- a/src/main/php/JavaSe8/Time.php
+++ b/src/main/php/JavaSe8/Time.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\ZonedDateTimePersistence\JavaSe8;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use PetrKnap\ZonedDateTimePersistence\DateTimeUtils;
+
+/**
+ * @phpstan-type LocalDateTime DateTimeImmutable&object{_local: null}
+ * @phpstan-type ZonedDateTime DateTimeImmutable&object{_zoned: null}
+ */
+final class Time
+{
+    public const TIMEZONE_LESS_FORMAT = 'Y-m-d H:i:s.u';
+    private const LOCAL_OFFSET = 0;
+
+    /**
+     * @param ZonedDateTime $zonedDateTime
+     *
+     * @return LocalDateTime
+     */
+    public static function toLocalDateTime(DateTimeImmutable $zonedDateTime): DateTimeImmutable
+    {
+        /** @var LocalDateTime */
+        return $zonedDateTime->getOffset() === self::LOCAL_OFFSET
+            ? $zonedDateTime // this is performance hack - input has correct offset
+            : DateTimeImmutable::createFromFormat(
+                self::TIMEZONE_LESS_FORMAT,
+                $zonedDateTime->format(self::TIMEZONE_LESS_FORMAT),
+                DateTimeUtils::offsetTimezone(self::LOCAL_OFFSET),
+            )
+        ;
+    }
+
+    /**
+     * `ZonedDateTime` factory / entrypoint
+     *
+     * @return ZonedDateTime
+     */
+    public static function zonedDateTime(DateTimeInterface $dateTime): DateTimeImmutable
+    {
+        /** @var ZonedDateTime */
+        return $dateTime instanceof DateTimeImmutable
+            ? $dateTime // this is performance hack - input has correct type
+            : DateTimeImmutable::createFromInterface($dateTime)
+        ;
+    }
+}

--- a/src/main/php/ZonedDateTimePersistence.php
+++ b/src/main/php/ZonedDateTimePersistence.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\ZonedDateTimePersistence;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+
+/**
+ * @phpstan-import-type LocalDateTime from JavaSe8\Time
+ * @phpstan-import-type ZonedDateTime from JavaSe8\Time
+ */
+final class ZonedDateTimePersistence
+{
+    /**
+     * @return ZonedDateTime
+     */
+    public static function computeUtcCompanion(
+        DateTimeInterface $zonedDateTime,
+    ): DateTimeImmutable {
+        return JavaSe8\Time::zonedDateTime($zonedDateTime)
+            ->setTimezone(new DateTimeZone('UTC'));
+    }
+
+    /**
+     * @param ($format is null ? DateTimeInterface : string) $localDateTime
+     * @param ($format is null ? DateTimeInterface : string) $utcCompanion
+     *
+     * @return ZonedDateTime
+     */
+    public static function computeZonedDateTime(
+        DateTimeInterface|string $localDateTime,
+        DateTimeInterface|string $utcCompanion,
+        string|null $format = null,
+    ): DateTimeImmutable {
+        $localDateTime = JavaSe8\Time::toLocalDateTime(
+            DateTimeUtils::parse($localDateTime, $format),
+        );
+        $utcCompanion = JavaSe8\Time::toLocalDateTime(
+            DateTimeUtils::parse($utcCompanion, $format),
+        );
+        $offset = DateTimeUtils::difference($localDateTime, $utcCompanion);
+        return DateTimeUtils::atOffset($utcCompanion, $offset);
+    }
+}

--- a/src/test/ReadmeTest.php
+++ b/src/test/ReadmeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap;
+
+use PetrKnap\Shorts\PhpUnit\MarkdownFileTestInterface;
+use PetrKnap\Shorts\PhpUnit\MarkdownFileTestTrait;
+use PetrKnap\ZonedDateTimePersistence\DateTimeWithUtcCompanion;
+use PHPUnit\Framework\TestCase;
+
+final class ReadmeTest extends TestCase implements MarkdownFileTestInterface
+{
+    use MarkdownFileTestTrait;
+
+    public static function getPathToMarkdownFile(): string
+    {
+        return __DIR__ . '/../../README.md';
+    }
+
+    public static function getExpectedOutputsOfPhpExamples(): iterable
+    {
+        return [
+            DateTimeWithUtcCompanion::class =>
+                '2025-10-26 02:45 GMT+0200: We still have summer time' . PHP_EOL .
+                '2025-10-26 02:15 GMT+0100: Now we have winter time' . PHP_EOL,
+        ];
+    }
+}

--- a/src/test/php/DateTimeUtilsTest.php
+++ b/src/test/php/DateTimeUtilsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\ZonedDateTimePersistence;
+
+use DateInterval;
+
+final class DateTimeUtilsTest extends TestCase
+{
+    public function testAtOffsetWorks(): void
+    {
+        $offset = new DateInterval('PT' . self::OFFSET . 'S');
+
+        $zonedDateTime = DateTimeUtils::atOffset($this->localDateTime, self::OFFSET);
+
+        self::assertSame([
+            'formated' => $this->localDateTime->add($offset)->format(self::FORMAT),
+            'timestamp' => $this->localDateTime->getTimestamp(),
+        ], [
+            'formated' => $zonedDateTime->format(self::FORMAT),
+            'timestamp' => $zonedDateTime->getTimestamp(),
+        ], 'Formated values must be shifted by an offset, but timestamps must be same.');
+    }
+}

--- a/src/test/php/DateTimeWithUtcCompanionTest.php
+++ b/src/test/php/DateTimeWithUtcCompanionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\ZonedDateTimePersistence;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class DateTimeWithUtcCompanionTest extends TestCase
+{
+    #[DataProvider('dataConstructsItself')]
+    public function testConstructsItself(
+        DateTimeWithUtcCompanion $dateTimeWithUtcCompanion,
+        DateTimeImmutable $expectedDateTime,
+        DateTimeImmutable $expectedUtcCompanion,
+    ): void {
+        self::assertZonedDateTime($expectedDateTime, $dateTimeWithUtcCompanion->dateTime);
+        self::assertZonedDateTime($expectedUtcCompanion, $dateTimeWithUtcCompanion->utcCompanion);
+    }
+
+    public static function dataConstructsItself(): array
+    {
+        $zonedDateTime = DateTimeUtils::parse(self::ZONED_DATETIME, self::ZONED_FORMAT);
+        $utcDateTime = ZonedDateTimePersistence::computeUtcCompanion($zonedDateTime);
+
+        return [
+            'zoned datetime' => [
+                new DateTimeWithUtcCompanion(
+                    dateTime: $zonedDateTime,
+                ),
+                $zonedDateTime,
+                $utcDateTime,
+            ],
+            'local datetime and local UTC companion' => [
+                new DateTimeWithUtcCompanion(
+                    dateTime: JavaSe8\Time::toLocalDateTime($zonedDateTime),
+                    utcCompanion: JavaSe8\Time::toLocalDateTime($utcDateTime),
+                ),
+                $zonedDateTime,
+                $utcDateTime,
+            ],
+            'zoned datetime and zoned UTC companion' => [
+                new DateTimeWithUtcCompanion(
+                    dateTime: $zonedDateTime,
+                    utcCompanion: $utcDateTime,
+                ),
+                $zonedDateTime,
+                $utcDateTime,
+            ],
+        ];
+    }
+}

--- a/src/test/php/JavaSe8/TimeTest.php
+++ b/src/test/php/JavaSe8/TimeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\ZonedDateTimePersistence\JavaSe8;
+
+use PetrKnap\ZonedDateTimePersistence\TestCase;
+
+final class TimeTest extends TestCase
+{
+    public function testToLocalDateTimeWorks(): void
+    {
+        $localDateTime = Time::toLocalDateTime($this->zonedDateTime);
+
+        self::assertSame([
+            'formated' => $this->zonedDateTime->format(self::FORMAT),
+            'timestamp' => $this->zonedDateTime->getTimestamp() + self::OFFSET,
+        ], [
+            'formated' => $localDateTime->format(self::FORMAT),
+            'timestamp' => $localDateTime->getTimestamp(),
+        ], 'Formated values must be the same, but timestamps must be shifted by an offset.');
+    }
+}

--- a/src/test/php/TestCase.php
+++ b/src/test/php/TestCase.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\ZonedDateTimePersistence;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase as Base;
+
+/**
+ * @phpstan-import-type LocalDateTime from JavaSe8\Time
+ * @phpstan-import-type ZonedDateTime from JavaSe8\Time
+ */
+abstract class TestCase extends Base
+{
+    protected const DATETIME = '2025-10-25 16:05:55.000000';
+    protected const FORMAT = JavaSe8\Time::TIMEZONE_LESS_FORMAT;
+    protected const OFFSET = 7200;
+    protected const ZONED_DATETIME = self::DATETIME . ' GMT+0200';
+    protected const ZONED_FORMAT = self::FORMAT . ' T';
+
+    /**
+     * @var LocalDateTime
+     */
+    protected DateTimeImmutable $localDateTime;
+    /**
+     * @var ZonedDateTime
+     */
+    protected DateTimeImmutable $zonedDateTime;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $dateTime = new DateTimeImmutable(self::ZONED_DATETIME);
+        $this->zonedDateTime = JavaSe8\Time::zonedDateTime($dateTime);
+        $this->localDateTime = JavaSe8\Time::toLocalDateTime($this->zonedDateTime);
+    }
+
+    protected static function assertZonedDateTime(DateTimeImmutable $expected, DateTimeImmutable $actual): void
+    {
+        self::assertSame(
+            $expected->format(self::ZONED_FORMAT),
+            $actual->format(self::ZONED_FORMAT),
+        );
+    }
+}

--- a/src/test/php/ZonedDateTimePersistenceTest.php
+++ b/src/test/php/ZonedDateTimePersistenceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PetrKnap\ZonedDateTimePersistence;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+
+final class ZonedDateTimePersistenceTest extends TestCase
+{
+    public function testComputesUtcCompanion(): void
+    {
+        $utcCompanion = ZonedDateTimePersistence::computeUtcCompanion($this->zonedDateTime);
+
+        self::assertEquals(0, $utcCompanion->getOffset());
+        self::assertEquals($this->zonedDateTime->getTimestamp(), $utcCompanion->getTimestamp());
+    }
+
+    #[DataProvider('dataComputesZonedDateTime')]
+    public function testComputesZonedDateTime(DateTimeImmutable $zonedDateTime): void
+    {
+        self::assertEquals(self::OFFSET, $zonedDateTime->getOffset());
+        self::assertZonedDateTime($this->zonedDateTime, $zonedDateTime);
+    }
+
+    public static function dataComputesZonedDateTime(): array
+    {
+        $zonedDateTime = JavaSe8\Time::zonedDateTime(new DateTimeImmutable(self::ZONED_DATETIME));
+        $utcCompanion = ZonedDateTimePersistence::computeUtcCompanion($zonedDateTime);
+        $localDateTime = JavaSe8\Time::toLocalDateTime($zonedDateTime);
+        return [
+            'local date-time + UTC companion' => [ZonedDateTimePersistence::computeZonedDateTime(
+                $localDateTime,
+                utcCompanion: $utcCompanion,
+            )],
+            'local date-time + UTC companion + format' => [ZonedDateTimePersistence::computeZonedDateTime(
+                $localDateTime->format(self::FORMAT),
+                utcCompanion: $utcCompanion->format(self::FORMAT),
+                format: self::FORMAT,
+            )],
+        ];
+    }
+}


### PR DESCRIPTION
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the following code for me?
>> ```php
>> /**
>>  * @phpstan-import-type LocalDateTime from JavaSe8\Time
>>  * @phpstan-import-type ZonedDateTime from JavaSe8\Time
>>  */
>> final class ZonedDateTimePersistence
>> {
>>     /**
>>      * @return ZonedDateTime
>>      */
>>     public static function computeUtcCompanion(
>>         DateTimeInterface $zonedDateTime,
>>     ): DateTimeImmutable {
>>         // ...
>>     }
>> 
>>     /**
>>      * @param ($format is null ? DateTimeInterface : string) $localDateTime
>>      * @param ($format is null ? DateTimeInterface : string) $utcCompanion
>>      *
>>      * @return ZonedDateTime
>>      */
>>     public static function computeZonedDateTime(
>>         DateTimeInterface|string $localDateTime,
>>         DateTimeInterface|string $utcCompanion,
>>         string|null $format = null,
>>     ): DateTimeImmutable {
>>         // ...
>>     }
>> }
>> 
>> /**
>>  * @phpstan-import-type LocalDateTime from JavaSe8\Time
>>  * @phpstan-import-type ZonedDateTime from JavaSe8\Time
>>  */
>> final class DateTimeWithUtcCompanion
>> {
>>     /**
>>      * @var ZonedDateTime
>>      */
>>     public readonly DateTimeImmutable $dateTime;
>>     /**
>>      * @var ZonedDateTime
>>      */
>>     public readonly DateTimeImmutable $utcCompanion;
>> 
>>     public function __construct(
>>         DateTimeInterface $dateTime,
>>         DateTimeInterface|null $utcCompanion = null,
>>     ) {
>>         // ...
>> 
>>         $this->dateTime = $dateTime;
>>         $this->utcCompanion = $utcCompanion;
>> 
>>         if ($this->utcCompanion->getOffset() !== 0) {
>>             throw new LogicException('$utcCompanion must have zero offset');
>>         } elseif (DateTimeUtils::difference($this->dateTime, $this->utcCompanion) !== 0) {
>>             throw new LogicException('$dateTime and $utcCompanion must have zero difference');
>>         }
>>     }
>> }
>> ```
>
> The code defines two final classes that handle time representations with UTC companions, using PHPStan type annotations for static analysis.
> 
> **📦 ZonedDateTimePersistence**
> 
> This utility class provides static methods to:
> - `computeUtcCompanion`: Given a `DateTimeInterface` object (assumed to be in a specific time zone), it returns a `DateTimeImmutable` version in UTC.
> - `computeZonedDateTime`: Combines a local date-time and its UTC companion (either as strings or `DateTimeInterface` objects) into a `DateTimeImmutable` object, optionally using a format.
> 
> **🧩 DateTimeWithUtcCompanion**
> 
> This class encapsulates a date-time and its UTC equivalent:
> - Stores both as `DateTimeImmutable` readonly properties.
> - Validates that:
>   - The UTC companion has a zero offset.
>   - The local and UTC times represent the same moment (no time difference).
> - Throws `LogicException` if either condition fails.
> 
> **🛠️ Purpose**
>
> Together, these classes help manage and validate date-time values with UTC counterparts, ensuring consistency and correctness in time zone handling.
>
>> Could you show me how to use it to persist current date in the database?
>
> Certainly! Here's how you could use the `ZonedDateTimePersistence` and `DateTimeWithUtcCompanion` classes to persist the current date-time (with its UTC companion) into a database using PDO in PHP.
> 
> **🧪 Step-by-Step Example**
> 
> ```php
> // Step 1: Get current local time (e.g., in Europe/Prague)
> $localDateTime = new DateTimeImmutable('now', new DateTimeZone('Europe/Prague'));
> 
> // Step 2: Compute UTC companion
> $utcCompanion = ZonedDateTimePersistence::computeUtcCompanion($localDateTime);
> 
> // Step 3: Validate and encapsulate
> $zonedPair = new DateTimeWithUtcCompanion($localDateTime, $utcCompanion);
> 
> // Step 4: Persist to database
> $pdo = new PDO('mysql:host=localhost;dbname=your_db', 'username', 'password');
> $stmt = $pdo->prepare('INSERT INTO timestamps (local_time, utc_time) VALUES (:local, :utc)');
> $stmt->execute([
>     ':local' => $zonedPair->dateTime->format('Y-m-d H:i:s'),
>     ':utc'   => $zonedPair->utcCompanion->format('Y-m-d H:i:s'),
> ]);
> ```
> 
> **🗃️ Table Structure Example**
> 
> Make sure your database table looks something like this:
> 
> ```sql
> CREATE TABLE timestamps (
>     id INT AUTO_INCREMENT PRIMARY KEY,
>     local_time DATETIME NOT NULL,
>     utc_time DATETIME NOT NULL
> );
> ```
> 
> This setup ensures that you're storing both the local time and its UTC equivalent, which is great for timezone-aware applications. Want to add timezone info or retrieve it later? I can help with that too.
>
>> Is there any way to do `ZonedDateTimePersistence` or `DateTimeWithUtcCompanion` better?
>
> Yes — both classes are solid, but there are definitely ways to improve their clarity, flexibility, and robustness. Here are some thoughtful suggestions:
>
> **🧠 `ZonedDateTimePersistence` Improvements**
>
> 1. **Clarify Return Types**
>    - The docblocks say `@return ZonedDateTime`, but the actual return type is `DateTimeImmutable`. This mismatch can confuse static analyzers and developers. Either:
>      - Change the return type to match the docblock (if using a custom `ZonedDateTime` class), or
>      - Update the docblock to reflect the actual return type.
> 2. **Improve Type Safety**
>    - Instead of accepting `DateTimeInterface|string`, consider using value objects or factory methods to enforce correct input formats and reduce ambiguity.
> 3. **Add Format Validation**
>    - If `$format` is provided, validate it early and throw a meaningful exception if it's invalid.
> 4. **Separate Concerns**
>    - Split `computeZonedDateTime` into two methods: one for parsing from strings, another for combining two `DateTimeInterface` objects. This improves readability and testability.
> 
> **🧩 `DateTimeWithUtcCompanion` Improvements**
> 
> 1. **Use Custom Value Objects**
>    - Instead of raw `DateTimeInterface`, consider a `ZonedDateTime` value object that encapsulates both the time and its zone. This makes the domain model more expressive.
> 2. **Constructor Validation**
>    - The constructor throws exceptions if the UTC offset isn’t zero or if the times differ. Consider moving this logic into a static factory method like `::fromPair()` to make intent clearer and allow for multiple construction paths.
> 3. **Add Accessors**
>    - Even though the properties are `readonly`, adding named getters like `getLocalTime()` and `getUtcTime()` improves encapsulation and future flexibility.
> 4. **Better Error Messages**
>    - The exceptions could include actual values to aid debugging:
>      ```php
>      throw new LogicException(sprintf(
>         'UTC companion must have zero offset, got %d seconds',
>         $utcCompanion->getOffset()
>      ));
>      ```
> 
> **🧰 Bonus Ideas**
> 
> - **Add Unit Tests**: These classes are perfect candidates for unit testing, especially around edge cases like DST transitions.
> - **Support Serialization**: If you're persisting these objects, consider implementing `__serialize()` / `__unserialize()` or `JsonSerializable`.
> - **Immutable Value Object**: Consider making `DateTimeWithUtcCompanion` a true value object with equality checks and immutability guarantees.
> 
> Would you like me to refactor one of these classes to show what this could look like in code?
>