### PR TITLE
`AsUtc::withFixedTimezone` marked as deprecated

### DIFF
--- a/src/main/php/AsUtc.php
+++ b/src/main/php/AsUtc.php
@@ -17,14 +17,9 @@ abstract class AsUtc
     /**
      * @internal
      *
-     * @var array<callable&array{class-string<self>, non-empty-string}>
-     *
-     * @note these methods must generate {@see Attribute::$set} which calls {@see AsUtcDateTime::normalizeValue()}
+     * @var callable generates {@see Attribute::$set} which calls {@see AsUtcDateTime::normalizeValue()} with {@see Carbon::$timezone} as fallback timezone
      */
-    public const CAST_ALTERNATIVES = [
-        [self::class, 'withFixedTimezone'],
-        [self::class, 'withSystemTimezone'],
-    ];
+    public const CAST_ALTERNATIVE = [self::class, 'withSystemTimezone'];
 
     /**
      * @see AsUtcDateTime
@@ -67,6 +62,10 @@ abstract class AsUtc
     }
 
     /**
+     * @todo BC remove it
+     *
+     * @deprecated use {@see self::withSystemTimezone()}
+     *
      * @note you can cast used attribute as readonly {@see AsUtc::dateTime()} or {@see AsPrivate}
      *
      * @see UtcWithTimezone

--- a/src/main/php/AsUtcDateTime.php
+++ b/src/main/php/AsUtcDateTime.php
@@ -102,18 +102,18 @@ final class AsUtcDateTime implements CastsAttributes
     public static function normalizeValue(
         DateTimeInterface|string|null $value,
         string $dateTimeFormat,
-        DateTimeZone|string $timezone,
+        DateTimeZone|string $fallbackTimezone,
     ): DateTimeInterface|null {
         if ($value === null || $value instanceof DateTimeInterface) {
             return $value;
         }
         try {
             /** @var Carbon */
-            return Carbon::createFromFormat($dateTimeFormat, $value, $timezone);
+            return Carbon::createFromFormat($dateTimeFormat, $value, $fallbackTimezone);
         } catch (InvalidFormatException $invalidFormatException) { // @phpstan-ignore catch.neverThrown
             try {
                 /** @var Carbon */
-                return Carbon::parse($value, $timezone);
+                return Carbon::parse($value, $fallbackTimezone);
             } catch (Throwable) {
                 throw $invalidFormatException;
             }
@@ -130,10 +130,7 @@ final class AsUtcDateTime implements CastsAttributes
                 '%s::$%s is registered as date, do not cast it twice; use %s instead',
                 get_class($model),
                 $key,
-                implode(' / ', array_map(
-                    static fn (array $factory): string => implode('::', $factory),
-                    AsUtc::CAST_ALTERNATIVES,
-                )),
+                implode('::', AsUtc::CAST_ALTERNATIVE),
             ), E_USER_WARNING);
         }
     }

--- a/src/test/php/EloquentTest.php
+++ b/src/test/php/EloquentTest.php
@@ -122,7 +122,7 @@ final class EloquentTest extends TestCase
             'Unexpected createdNote.created_at_utc',
         );
         self::assertDateTimeEquals(
-            $utcDateTime,
+            $zonedDateTime,
             $loadedNote->created_at_utc,
             'Unexpected loadedNote.created_at_utc',
         );

--- a/src/test/php/Some/NoteModel.php
+++ b/src/test/php/Some/NoteModel.php
@@ -35,10 +35,9 @@ final class NoteModel extends Model
      */
     protected function createdAtUtc(): Attribute
     {
-        return AsUtc::withFixedTimezone(
+        return AsUtc::withSystemTimezone(
             'created_at_utc',
             $this->getDateFormat(),
-            'UTC',
         );
     }
 


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.

`AsUtc::withFixedTimezone` assumes that values being set are date-times in a fixed timezone (e.g. UTC). In practice, many Laravel applications pass plain date-time strings in the **system timezone**, even when the original input contained timezone information. A common pattern is converting a value from fixed timezone to the system timezone for display and then sending it back as a string in system timezone (not fixed timezone) without timezone metadata. Since a string does not carry timezone context, it is impossible to reliably determine whether it represents a fixed or system timezone, which leads to silent and incorrect conversions. Deprecating this method avoids this ambiguity and the resulting bugs.

Additionally, `AsUtc::withFixedTimezone` cannot be implemented as an embeddable in Doctrine or JPA. It exists as a Laravel-specific workaround, making it a special-case hack rather than a portable or robust solution.